### PR TITLE
resolved navbar issues tc 013 to 018

### DIFF
--- a/src/Components/Navbar/Desktop.jsx
+++ b/src/Components/Navbar/Desktop.jsx
@@ -8,7 +8,6 @@ export const DesktopMenu = ({ open }) => {
       <NavLinks Open={true} />
       <a
         href="http://mulearn.org/careers"
-        target="_blank"
         rel="noopener noreferrer"
         className="py-7 px-3 inline-block"
       >

--- a/src/Components/Navbar/Mobile.jsx
+++ b/src/Components/Navbar/Mobile.jsx
@@ -49,7 +49,7 @@ export const MobileMenu = ({ setNotificationOpen, setOpen, handleScrolling, open
             <NavLinks />
       
                 <a
-                    href="https://mulear.org/careers"
+                    href="https://mulearn.org/careers"
                     className="py-4 px-7 inline-block uppercase hover:text-orange-500 text-[13px]"
                     onClick={() => {
                         setOpen(false);


### PR DESCRIPTION
# Description

careers header in desktop navbar opening new tab
careers header in mobile navbar redirecting to non existent site

## Fixes  (issue)
corrected typo in mobile view careers href
removed target attribute from careers to prevent new tab opening
## Type of change

Please delete options that are not relevant.
- [x ] Bugfix (non-breaking change which fixes an issue)

# Checklist:
- [x ] My changes generate no new warnings
